### PR TITLE
Remove platforms from tags

### DIFF
--- a/pipeline/extract_epic.py
+++ b/pipeline/extract_epic.py
@@ -100,16 +100,27 @@ def get_platform_ids(game_tags: list[str]) -> list[int]:
     return platform_ids
 
 
+def remove_platforms_from_tags(game_tags: list[str]) -> list[str]:
+    """Removes platform(s) from game tags list."""
+    platforms = ['Windows', 'Mac OS']
+
+    for platform in platforms:
+        if platform in game_tags:
+            game_tags.remove(platform)
+    return game_tags
+
+
 def get_game_details(game_obj: dict) -> list:
     """Returns list of relevant details from game json object."""
     title = get_game_title(game_obj)
     description = get_game_description(game_obj)
-    tags = get_tags(game_obj)
+    tags_with_platform = get_tags(game_obj)
+    platform_ids = get_platform_ids(tags_with_platform)
+    tags = remove_platforms_from_tags(tags_with_platform)
     developer = get_developer(game_obj)
     publisher = get_publisher(game_obj)
     price = get_price(game_obj)
     release_date = get_release_date(game_obj)
-    platform_ids = get_platform_ids(tags)
     return [title, description, price, developer, publisher,
             release_date, None, 3, tags, platform_ids]
 
@@ -134,4 +145,4 @@ def epic_extract_process(config):
 
 if __name__ == "__main__":
     load_dotenv()
-    epic_extract_process(environ)
+    games = epic_extract_process(environ)

--- a/pipeline/test_epic.py
+++ b/pipeline/test_epic.py
@@ -26,7 +26,7 @@ def test_correct_game_details_pulled(epic_game_data_game_obj):
                       19.99, 'Hack The Publisher', 'Freedom Games', datetime.datetime(
                           2024, 4, 24, 16, 0), None, 3,
                       ['Action', 'Action-Adventure', 'Single Player',
-                       'Windows', 'Indie', 'Mac OS'], [1, 2]]
+                       'Indie'], [1, 2]]
 
 
 def test_no_new_games(requests_mock, epic_empty_post_request):
@@ -53,4 +53,4 @@ def test_no_one_new_games(requests_mock, epic_game_post_response):
                       19.99, 'Hack The Publisher', 'Freedom Games', datetime.datetime(
                           2024, 4, 24, 16, 0),
                        None, 3, ['Action', 'Action-Adventure',
-                                 'Single Player', 'Windows', 'Indie', 'Mac OS'], [1, 2]]]
+                                 'Single Player', 'Indie'], [1, 2]]]


### PR DESCRIPTION
- Removal of platforms in game tags list (`extract_epic.py`)
- Updated test file `test_epic.py` expected results to reflect change in `extract_epic.py`

Now we do not have to worry about platforms being in the tags when trying to upload to the database.

Closes #87 