### PR TITLE
rename url

### DIFF
--- a/pipeline/extract/gog/extract_gog.py
+++ b/pipeline/extract/gog/extract_gog.py
@@ -163,7 +163,7 @@ def search_pages_last_day() -> list:
     load_dotenv()
     counter = 1
     games_from_page = req.get(
-        f'{ENV["SCRAPING_URL"]}&page={counter}', timeout=5)
+        f'{ENV["GOG_BASE_URL"]}&page={counter}', timeout=5)
     page_soup = BeautifulSoup(games_from_page.text, features="html.parser")
     games_soup = page_soup.findAll('product-tile', class_='ng-star-inserted')
     game_data_list = get_games_from_page(games_soup)
@@ -172,7 +172,7 @@ def search_pages_last_day() -> list:
         sleep(1)
         counter += 1
         games_from_page = req.get(
-            f'{ENV["SCRAPING_URL"]}&page={counter}', timeout=5)
+            f'{ENV["GOG_BASE_URL"]}&page={counter}', timeout=5)
         page_soup = BeautifulSoup(games_from_page.text, features="html.parser")
         games_soup = page_soup.findAll(
             'product-tile', class_='ng-star-inserted')


### PR DESCRIPTION
Rename the GOG environment variable so it is standardised with the other website extract files.