### PR TITLE
Added in a file to contain a global variable for tag exceptions

### DIFF
--- a/pipeline/load/Dockerfile
+++ b/pipeline/load/Dockerfile
@@ -6,6 +6,8 @@ COPY requirements.txt .
 
 RUN pip install -r requirements.txt
 
+COPY load_tag_exceptions.py .
+
 COPY load.py .
 
 CMD [ "load.handler" ]

--- a/pipeline/load/README.md
+++ b/pipeline/load/README.md
@@ -2,24 +2,27 @@
 
 This Folder is responsible for loading data into in our database.
 
+### The Why
+This folder is important because it bridges the gap between collecting the data with our extraction files and our database. It takes the data, cleans it and then loads it into our database.  
+
 
 ## Requirements
 The requirements for this folder are:
-- psycopg2-binary
-- pytest
-- pytest-cov
-- pylint
+- ```psycopg2-binary```
+- ```pytest```
+- ```pytest-cov```
+- ```pylint```
 
 
 ## Environment Variables
 In order to run the scripts you will need the following environment variables, in a *.env* file:
 
 
-- DB_PASSWORD
-- DB_NAME
-- DB_USER
-- DB_HOST
-- DB_PORT
+- ```DB_PASSWORD```
+- ```DB_NAME```
+- ```DB_USER```
+- ```DB_HOST```
+- ```DB_PORT```
 
 
 ## The Scripts
@@ -38,15 +41,15 @@ This script contains all discrepancies in game tags along platforms, and is used
 This script is used to dockerise **load.py**.  
   
   Run from the command line using: 
-  >docker build -t load .  
-  >docker run --env-file .env load  
+  >```docker build -t load .```  
+  >```docker run --env-file .env load```  
 
 
 - **test_load.py**  
 This script tests **load.py**.  
 
    Run from the command line using: 
-  >pytest test_load.py
+  >```pytest test_load.py```
 
 
 - **conftest.py**  

--- a/pipeline/load/README.md
+++ b/pipeline/load/README.md
@@ -30,7 +30,10 @@ This script uploads data to our database.
 
    Run from the command line using: 
   >python3 load.py
-  
+
+- **load_tag_exceptions.py**
+This script contains all discrepancies in game tags along platforms, and is used to avoid duplicate values when uploading to the database.
+
 - **Dockerfile**  
 This script is used to dockerise **load.py**.  
   

--- a/pipeline/load/load.py
+++ b/pipeline/load/load.py
@@ -14,10 +14,7 @@ from psycopg2 import connect
 from psycopg2.extras import RealDictCursor, RealDictRow
 from psycopg2.extensions import connection
 
-
-TAG_EXCEPTIONS = {'Single Player': 'Singleplayer',
-                  'Rogue-Lite': 'Roguelite',
-                  }
+from load_tag_exceptions import tag_exception_dict
 
 
 def get_db_connection(config) -> connection:
@@ -166,6 +163,8 @@ def input_game_tags_into_db(game_data: list[list], conn: connection) -> None:
     different to each website, we refer to the constant variable TAG_EXCEPTIONS,
     appending the tag iterand into the table if no similar entries are detected."""
 
+    tag_exceptions = tag_exception_dict()
+
     with conn.cursor() as cur:
         for game in game_data:
 
@@ -177,8 +176,8 @@ def input_game_tags_into_db(game_data: list[list], conn: connection) -> None:
                 for tag in game_tags:
                     tag_formatted = tag.title()
 
-                    if tag_formatted in TAG_EXCEPTIONS.keys():
-                        tag_formatted = TAG_EXCEPTIONS[tag_formatted]
+                    if tag_formatted in tag_exceptions.keys():
+                        tag_formatted = tag_exceptions[tag_formatted]
 
                     cur.execute("""SELECT tag_id FROM tag
                                 WHERE tag_name = %s""",

--- a/pipeline/load/load_tag_exceptions.py
+++ b/pipeline/load/load_tag_exceptions.py
@@ -1,0 +1,14 @@
+"""
+As tag formatting differs between gaming websites, this file stores all 
+possible exception cases where this can occur. Due to the low number of cases 
+where this occurs, as well as a wide range of irregularities in the length of tags 
+and the frequency of differences, we use a dictionary mapping to navigate the 
+tag inconsistencies.
+"""
+
+
+def tag_exception_dict() -> dict:
+    """Returns a dict object containing a mapping of all tag exceptions
+    between gaming websites."""
+
+    return {'Single Player': 'Singleplayer', 'Rogue-Lite': 'Roguelite'}


### PR DESCRIPTION
Summary:

- Added in new file `load_tag_exceptions.py` to contain the global variable, instead of having it in `load.py`
- Adjusted `load.py` and `load/README.md` to cater for this